### PR TITLE
Develop - Blockchain Logic, UserItem Logic, Wallet UI | Test - UI Based Fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache node modules
+      - name: Cache Node Modules
         uses: actions/cache@v2
         env:
           cache-name: cache-node-modules
@@ -26,7 +26,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install Dependencies
-        run: npm i
+        run: npm ci
 
       - name: Build
         run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache node modules
+      - name: Cache Node Modules
         uses: actions/cache@v2
         env:
           cache-name: cache-node-modules
@@ -22,11 +22,6 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-
-      - name: Test using Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12"
 
       - name: Install Dependencies
         run: npm ci

--- a/src/components/Block/BlockChain.tsx
+++ b/src/components/Block/BlockChain.tsx
@@ -11,8 +11,8 @@ export default function BlockChain(): JSX.Element {
 
   return (
     <div className="mx-3 row flex-nowrap overflow-auto">
-      {state.chain.map((block, i: number) => (
-        <Block details={block} key={`block${i}`} />
+      {state.chain.map((block) => (
+        <Block block={block} key={Math.random()} />
       ))}
     </div>
   );

--- a/src/components/Block/PreviewBlock.tsx
+++ b/src/components/Block/PreviewBlock.tsx
@@ -61,9 +61,9 @@ export default function PreviewBlock(): JSX.Element {
 
   return (
     <div className="container-fluid row d-flex justify-content-center mx-auto my-3">
-      <div className="overflow-auto mb-2">
+      <div className="mb-2 d-none d-lg-block">
         <h4 className="font-weight-bold text-center">Merkle Tree Visualization</h4>
-        <canvas ref={treeCanvas} className="border border-dark rounded" width={1500} />
+        <canvas ref={treeCanvas} className="border border-dark rounded" width={window.outerWidth * 0.7} />
       </div>
 
       <Statistics

--- a/src/components/Block/Statistics.tsx
+++ b/src/components/Block/Statistics.tsx
@@ -11,7 +11,7 @@ interface IStats {
   solution: string;
   setIsValid: (arg: boolean) => void;
   setSolution: (arg: string) => void;
-  details?: IBlock;
+  block?: IBlock;
 }
 
 export default function Statistics(props: IStats): JSX.Element {
@@ -23,13 +23,16 @@ export default function Statistics(props: IStats): JSX.Element {
   const [disableMineBtn, setDisableMineBtn] = useState<boolean>(false);
 
   async function handleMine() {
-    setDisableMineBtn(true);
     nonce.current = Math.round(Math.random() * 1e6);
+
+    setDisableMineBtn(true);
     const hash = await mine(nonce.current, setHeader, setTarget, props.setSolution, props.setIsValid);
-    if (props.chain && props.details) {
-      await propagateBlockStatus(state, dispatch, props.details, hash, true);
-    }
     setDisableMineBtn(false);
+
+    // propagate changes if needed
+    if (props.chain && props.block) {
+      await propagateBlockStatus(state, dispatch, props.block, hash, true);
+    }
   }
 
   return (

--- a/src/components/Transaction/Send.tsx
+++ b/src/components/Transaction/Send.tsx
@@ -22,7 +22,7 @@ export default function Send(props: ISend): JSX.Element {
         <InputGroup className="mb-2">
           <Form.Control type="number" defaultValue={props.details.amount} disabled />
           <InputGroup.Prepend>
-            <InputGroup.Text>LC</InputGroup.Text>
+            <InputGroup.Text className="rounded-right border-left-0">LC</InputGroup.Text>
           </InputGroup.Prepend>
         </InputGroup>
       </Form.Group>

--- a/src/components/Transaction/Sign.tsx
+++ b/src/components/Transaction/Sign.tsx
@@ -48,7 +48,7 @@ export default function Sign({ validated, signed, handleSubmit }: ISign): JSX.El
             required
           />
           <InputGroup.Prepend>
-            <InputGroup.Text>LC</InputGroup.Text>
+            <InputGroup.Text className="rounded-right border-left-0">LC</InputGroup.Text>
           </InputGroup.Prepend>
         </InputGroup>
       </Form.Group>

--- a/src/components/User/KeyGeneration.tsx
+++ b/src/components/User/KeyGeneration.tsx
@@ -48,13 +48,9 @@ export default function KeyGeneration(): JSX.Element {
   }
 
   const togglePrivateKey = () => {
-    if (privateKeyRef.current) {
-      if (privateKeyRef.current.value.includes("◦")) {
-        privateKeyRef.current.value = state.user.privateKey;
-      } else {
-        privateKeyRef.current.value = new Array(privateKeyRef.current.value.length).fill("◦").join("");
-      }
-    }
+    const show = privateKeyRef.current?.value.includes("◦");
+    const hiddenVal = new Array(state.user.privateKey.length).fill("◦").join("");
+    (privateKeyRef.current as HTMLTextAreaElement).value = show ? state.user.privateKey : hiddenVal;
   };
 
   return (

--- a/src/components/User/KeyGeneration.tsx
+++ b/src/components/User/KeyGeneration.tsx
@@ -12,7 +12,7 @@ import "./User.css";
 export default function KeyGeneration(): JSX.Element {
   const { state, dispatch } = useContext(AppContext) as { state: IState; dispatch: React.Dispatch<IAction> };
 
-  const numRows = useRef(3);
+  const numRows = useRef(4);
   const publicKeyRef = useRef<HTMLTextAreaElement>(null);
   const privateKeyRef = useRef<HTMLTextAreaElement>(null);
 
@@ -63,6 +63,7 @@ export default function KeyGeneration(): JSX.Element {
           aria-label="publicKey"
           as="textarea"
           rows={numRows.current}
+          className="rounded-right"
           defaultValue={state.user?.publicKey ?? ""}
           isValid={copied[0]}
           onFocus={(e: React.FocusEvent<HTMLTextAreaElement>) => copyKey(e, setCopied, "public")}
@@ -89,14 +90,14 @@ export default function KeyGeneration(): JSX.Element {
           readOnly
           ref={privateKeyRef}
         />
-        <Form.Control.Feedback type="valid">Copied to clipboard!</Form.Control.Feedback>
         <InputGroup.Append>
-          <InputGroup.Text>
+          <InputGroup.Text className="rounded-right">
             <span id="private-reveal-eyes" onClick={togglePrivateKey}>
               👀
             </span>
           </InputGroup.Text>
         </InputGroup.Append>
+        <Form.Control.Feedback type="valid">Copied to clipboard!</Form.Control.Feedback>
       </InputGroup>
     </div>
   );

--- a/src/components/User/KeyGeneration.tsx
+++ b/src/components/User/KeyGeneration.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useContext, useEffect } from "react";
-import { Form } from "react-bootstrap";
+import { Form, InputGroup } from "react-bootstrap";
 
 import { AppContext } from "../../context/AppContext";
 import { IAction, IState } from "../../typings/AppTypes";
@@ -54,11 +54,11 @@ export default function KeyGeneration(): JSX.Element {
   };
 
   return (
-    <div className="container-fluid row d-flex align-items-center justify-content-center mx-auto">
-      <Form.Group className="user-key col-5 px-0">
-        <Form.Label className="mb-3" htmlFor="publicKey">
-          <h4 className="mb-0">Public:</h4>
-        </Form.Label>
+    <div className="container-fluid row d-flex align-items-center justify-content-center mx-1 mt-0 mt-lg-5 mb-0 mb-lg-5">
+      <InputGroup className="user-key col-12 col-lg-5 px-0 mr-0 mr-lg-3">
+        <InputGroup.Prepend>
+          <InputGroup.Text>Public</InputGroup.Text>
+        </InputGroup.Prepend>
         <Form.Control
           aria-label="publicKey"
           as="textarea"
@@ -71,17 +71,13 @@ export default function KeyGeneration(): JSX.Element {
           ref={publicKeyRef}
         />
         <Form.Control.Feedback type="valid">Copied to clipboard!</Form.Control.Feedback>
-      </Form.Group>
+      </InputGroup>
 
-      <Form.Group className="user-key col-5 px-0 ml-4">
-        <Form.Label className="mb-3" htmlFor="privateKey">
-          <h4 className="mb-0">
-            Private:{" "}
-            <span id="private-reveal-eyes" onClick={togglePrivateKey}>
-              👀
-            </span>
-          </h4>
-        </Form.Label>
+      <InputGroup className="user-key col-12 col-lg-5 px-0">
+        <InputGroup.Prepend>
+          <InputGroup.Text>Private</InputGroup.Text>
+        </InputGroup.Prepend>
+
         <Form.Control
           aria-label="privateKey"
           as="textarea"
@@ -94,7 +90,14 @@ export default function KeyGeneration(): JSX.Element {
           ref={privateKeyRef}
         />
         <Form.Control.Feedback type="valid">Copied to clipboard!</Form.Control.Feedback>
-      </Form.Group>
+        <InputGroup.Append>
+          <InputGroup.Text>
+            <span id="private-reveal-eyes" onClick={togglePrivateKey}>
+              👀
+            </span>
+          </InputGroup.Text>
+        </InputGroup.Append>
+      </InputGroup>
     </div>
   );
 }

--- a/src/components/User/User.css
+++ b/src/components/User/User.css
@@ -11,5 +11,5 @@
   background-color: white;
   margin: 1em 0.5em;
   padding: 1em;
-  min-width: 12rem;
+  width: 14rem;
 }

--- a/src/components/User/UserItems.tsx
+++ b/src/components/User/UserItems.tsx
@@ -8,7 +8,13 @@ import "./User.css";
 
 export default function UserItems(): JSX.Element {
   const { state } = useContext(AppContext) as { state: IState; dispatch: React.Dispatch<IAction> };
-  const [copied, setCopied] = useState<boolean[]>([false]);
+  const [copied, setCopied] = useState<boolean[]>(new Array(state.users.length).fill(false));
+
+  function resetCopy(index: number): void {
+    const newCopied = JSON.parse(JSON.stringify(copied));
+    newCopied[index] = false;
+    setCopied(newCopied);
+  }
 
   return (
     <div className="container-fluid mb-2">
@@ -16,21 +22,25 @@ export default function UserItems(): JSX.Element {
       <div className="row flex-nowrap overflow-auto bg-dark mx-1 px-2 rounded">
         {state.users?.map((user: IUser, i: number) => {
           return (
-            <Form className="user-item rounded" key={`user${i}`}>
-              <Form.Group>
-                <Form.Text className="font-weight-bold mb-1 my-0">Public Key</Form.Text>
+            <Form className="user-item rounded flex-shrink-0" key={`user${i}`}>
+              <InputGroup>
+                <InputGroup.Prepend>
+                  <InputGroup.Text>🔑</InputGroup.Text>
+                </InputGroup.Prepend>
                 <Form.Control
                   aria-label="User Public Key"
                   type="text"
                   className="text-truncate"
-                  onFocus={(e: React.FocusEvent<HTMLInputElement>) => copyKey(e, setCopied)}
-                  onBlur={() => setCopied([false])}
+                  onFocus={(e: React.FocusEvent<HTMLInputElement>) =>
+                    copyKey(e, setCopied, undefined, i, state.users.length)
+                  }
+                  onBlur={() => resetCopy(i)}
                   defaultValue={user.publicKey}
-                  isValid={copied[0]}
+                  isValid={copied[i]}
                   readOnly
                 />
                 <Form.Control.Feedback type="valid">Copied to clipboard</Form.Control.Feedback>
-              </Form.Group>
+              </InputGroup>
 
               <InputGroup className="mt-2">
                 <Form.Control aria-label="balance" type="number" defaultValue={user.balance} disabled />

--- a/src/components/User/UserItems.tsx
+++ b/src/components/User/UserItems.tsx
@@ -30,7 +30,7 @@ export default function UserItems(): JSX.Element {
                 <Form.Control
                   aria-label="User Public Key"
                   type="text"
-                  className="text-truncate"
+                  className="text-truncate rounded-right"
                   onFocus={(e: React.FocusEvent<HTMLInputElement>) =>
                     copyKey(e, setCopied, undefined, i, state.users.length)
                   }

--- a/src/reducers/AppReducer.ts
+++ b/src/reducers/AppReducer.ts
@@ -44,9 +44,10 @@ export const AppReducer = (state: IState, action: IAction): IState => {
 
     case ACTIONS.UPDATE_BLOCK: {
       const { block } = action.payload as { block: IBlock };
-      state.chain[block.index] = block;
-      localStorage.setItem("chain", JSON.stringify(state.chain));
-      return state;
+      const ogState = JSON.parse(JSON.stringify(state));
+      ogState.chain[block.index] = block;
+      localStorage.setItem("chain", JSON.stringify(ogState.chain));
+      return { ...ogState, chain: ogState.chain };
     }
 
     default:

--- a/src/utils/Tree.ts
+++ b/src/utils/Tree.ts
@@ -54,7 +54,7 @@ export class Tree {
   #ctx: CanvasRenderingContext2D | null;
 
   constructor(canvas: HTMLCanvasElement, transactions: ITransaction[]) {
-    const xStart = window.innerWidth < 1200 ? window.innerWidth * 1.8 : (window.innerWidth / 2) * 0.8;
+    const xStart = window.innerWidth < 1200 ? window.innerWidth * 1.8 : (window.innerWidth / 2) * 0.7;
     this.#root = null;
     this.#transactionSignatures = transactions.map((transaction) => transaction.signature.slice(0, 25) + "...");
     this.#startPosition = { x: xStart, y: 5 };

--- a/src/utils/copyInput.ts
+++ b/src/utils/copyInput.ts
@@ -1,7 +1,9 @@
 export function copyKey(
   e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>,
   setCopied: (arg: boolean[]) => void,
-  type?: "public" | "private"
+  type?: "public" | "private",
+  index?: number,
+  totalUsers?: number
 ): void {
   const visible = !e.target.value.includes("◦");
   if (visible) {
@@ -17,6 +19,8 @@ export function copyKey(
     setCopied([isPublic, !isPublic && visible]);
   } else {
     // user items, copying public key
-    setCopied([true]);
+    const newCopied = new Array(totalUsers).fill(false);
+    newCopied[index as number] = true;
+    setCopied(newCopied);
   }
 }

--- a/src/utils/propagate.ts
+++ b/src/utils/propagate.ts
@@ -5,29 +5,24 @@ import { digestMessage } from "./conversion";
 export async function propagateBlockStatus(
   state: IState,
   dispatch: React.Dispatch<IAction>,
-  details: IBlock,
+  block: IBlock,
   prevHash: string,
   skipFirstUpdate: boolean,
   newRoot?: string,
   transactions?: ITransaction[],
   timestamp = Date.now()
 ): Promise<void> {
-  const index = details.index;
+  const index = block.index;
 
   for (let i = index; i < state.chain.length; i++) {
     const merkleRoot = newRoot && i === index ? newRoot : state.chain[i].merkleRoot;
     const currHash = i === index ? prevHash : await digestMessage(i + prevHash + merkleRoot);
+    const valid = skipFirstUpdate ? i === index : false;
+    const showTrans = state.chain[i].showTrans ?? false;
+    prevHash = i === index ? block.prevHash : prevHash;
+    transactions = i === index && transactions ? transactions : state.chain[i].transactions;
 
-    const newBlock = {
-      index: i,
-      timestamp,
-      prevHash: i === index ? details.prevHash : prevHash,
-      currHash,
-      transactions: i === index && transactions ? transactions : state.chain[i].transactions,
-      merkleRoot,
-      valid: skipFirstUpdate ? i === index : false,
-      showTrans: state.chain[i].showTrans ?? false
-    };
+    const newBlock = { index: i, timestamp, prevHash, currHash, transactions, merkleRoot, valid, showTrans };
 
     prevHash = currHash; // next block's prevHash is this block's currHash
 

--- a/tests/unit/User/KeyGeneration.spec.tsx
+++ b/tests/unit/User/KeyGeneration.spec.tsx
@@ -27,14 +27,8 @@ it("renders correctly", () => {
     </AppContext.Provider>
   );
 
-  const publicTitle = screen.getByRole("heading", { name: /Public:/i, level: 4 });
-  const privateTitle = screen.getByRole("heading", { name: /Private:/i, level: 4 });
-  const publicField = screen.getByRole("textbox", { name: /publicKey/i });
-  const privateField = screen.getByRole("textbox", { name: /privateKey/i });
-
-  [publicTitle, privateTitle, publicField, privateField].forEach((elem) => {
-    expect(elem).toBeInTheDocument();
-  });
+  expect(screen.getByRole("textbox", { name: /publicKey/i })).toBeInTheDocument();
+  expect(screen.getByRole("textbox", { name: /privateKey/i })).toBeInTheDocument();
 
   expect(asFragment()).toMatchSnapshot();
 });

--- a/tests/unit/User/__snapshots__/KeyGeneration.spec.tsx.snap
+++ b/tests/unit/User/__snapshots__/KeyGeneration.spec.tsx.snap
@@ -3,21 +3,20 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="container-fluid row d-flex align-items-center justify-content-center mx-auto"
+    class="container-fluid row d-flex align-items-center justify-content-center mx-1 mt-0 mt-lg-5 mb-0 mb-lg-5"
   >
     <div
-      class="user-key col-5 px-0 form-group"
+      class="user-key col-12 col-lg-5 px-0 mr-0 mr-lg-3 input-group"
     >
-      <label
-        class="mb-3 form-label"
-        for="publicKey"
+      <div
+        class="input-group-prepend"
       >
-        <h4
-          class="mb-0"
+        <span
+          class="input-group-text"
         >
-          Public:
-        </h4>
-      </label>
+          Public
+        </span>
+      </div>
       <textarea
         aria-label="publicKey"
         class="form-control"
@@ -33,23 +32,17 @@ exports[`renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="user-key col-5 px-0 ml-4 form-group"
+      class="user-key col-12 col-lg-5 px-0 input-group"
     >
-      <label
-        class="mb-3 form-label"
-        for="privateKey"
+      <div
+        class="input-group-prepend"
       >
-        <h4
-          class="mb-0"
+        <span
+          class="input-group-text"
         >
-          Private: 
-          <span
-            id="private-reveal-eyes"
-          >
-            👀
-          </span>
-        </h4>
-      </label>
+          Private
+        </span>
+      </div>
       <textarea
         aria-label="privateKey"
         class="form-control"
@@ -62,6 +55,19 @@ exports[`renders correctly 1`] = `
         class="valid-feedback"
       >
         Copied to clipboard!
+      </div>
+      <div
+        class="input-group-append"
+      >
+        <span
+          class="input-group-text"
+        >
+          <span
+            id="private-reveal-eyes"
+          >
+            👀
+          </span>
+        </span>
       </div>
     </div>
   </div>

--- a/tests/unit/User/__snapshots__/KeyGeneration.spec.tsx.snap
+++ b/tests/unit/User/__snapshots__/KeyGeneration.spec.tsx.snap
@@ -19,9 +19,9 @@ exports[`renders correctly 1`] = `
       </div>
       <textarea
         aria-label="publicKey"
-        class="form-control"
+        class="rounded-right form-control"
         readonly=""
-        rows="3"
+        rows="4"
       >
         3059301306072a8648ce3d020106082a8648ce3d030107034200048fa7d69599babb
       </textarea>
@@ -47,20 +47,15 @@ exports[`renders correctly 1`] = `
         aria-label="privateKey"
         class="form-control"
         readonly=""
-        rows="3"
+        rows="4"
       >
         ◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦◦
       </textarea>
       <div
-        class="valid-feedback"
-      >
-        Copied to clipboard!
-      </div>
-      <div
         class="input-group-append"
       >
         <span
-          class="input-group-text"
+          class="rounded-right input-group-text"
         >
           <span
             id="private-reveal-eyes"
@@ -68,6 +63,11 @@ exports[`renders correctly 1`] = `
             👀
           </span>
         </span>
+      </div>
+      <div
+        class="valid-feedback"
+      >
+        Copied to clipboard!
       </div>
     </div>
   </div>

--- a/tests/unit/User/__snapshots__/UserItems.spec.tsx.snap
+++ b/tests/unit/User/__snapshots__/UserItems.spec.tsx.snap
@@ -30,7 +30,7 @@ exports[`renders correctly 1`] = `
           </div>
           <input
             aria-label="User Public Key"
-            class="text-truncate form-control"
+            class="text-truncate rounded-right form-control"
             readonly=""
             type="text"
             value="3059301306072a8648ce3d020106082a8648ce3d030107034200048fa7d69599babb"

--- a/tests/unit/User/__snapshots__/UserItems.spec.tsx.snap
+++ b/tests/unit/User/__snapshots__/UserItems.spec.tsx.snap
@@ -14,16 +14,20 @@ exports[`renders correctly 1`] = `
       class="row flex-nowrap overflow-auto bg-dark mx-1 px-2 rounded"
     >
       <form
-        class="user-item rounded"
+        class="user-item rounded flex-shrink-0"
       >
         <div
-          class="form-group"
+          class="input-group"
         >
-          <small
-            class="font-weight-bold mb-1 my-0 form-text"
+          <div
+            class="input-group-prepend"
           >
-            Public Key
-          </small>
+            <span
+              class="input-group-text"
+            >
+              🔑
+            </span>
+          </div>
           <input
             aria-label="User Public Key"
             class="text-truncate form-control"


### PR DESCRIPTION
## Added:
- Spinner to `mining button` on both `Preview` and blockchain `Block` to indicate when mining is in process
- Mining button disable during mining

## Fixed:
- Rendering test for `public` & `private` key boxes (no more headings above them)
- Prevented shrinking of user items with `flex-shrink-0`
- Logic with copying their public keys
- Blockchain Shrinking
- Re-rendering issue (problem was key - should be random since state updates)
- Fixed mining wait icon logic to prevent memory leak warning
- Private key reveal feedback placement (before it broke the structure of the *appended* reveal eyes)
- Border rounding on inputs and textareas

## Changed:
- Cleaned up UI on Wallet page (no more headers above key text area

## Removed:
- Merkle tree visualization from smaller (than `lg`) devices